### PR TITLE
feat(cli): inject prisma generate scripts to prevent stale client after migrate dev

### DIFF
--- a/packages/cli/src/commands/generate-app.ts
+++ b/packages/cli/src/commands/generate-app.ts
@@ -9,6 +9,7 @@ import { generateTypeOrmAuthServices } from '../lib/generate-typeorm-auth-servic
 import { getPrismaServiceFile, getPrismaModuleFile, getPrismaAdapterPackage } from '../templates/prisma-setup.template';
 import { getDataSourceFile, getDatabaseModuleFile, getTypeOrmDriverPackage } from '../templates/typeorm-setup.template';
 import { configurePrismaGenerator, ignoreGeneratedPrismaClient } from '../lib/configure-prisma-generator';
+import { injectPrismaScripts } from '../lib/inject-prisma-scripts';
 import { resolveDatabaseAndOrm } from '../lib/resolve-orm';
 import { nestExtendedDep } from '../lib/local-packages';
 
@@ -211,6 +212,11 @@ export const generateAppAction = async (appName: string, options: AppOptions = {
         // generated client out of version control.
         configurePrismaGenerator(appDir);
         ignoreGeneratedPrismaClient(appDir);
+
+        // Inject `prisma:migrate` / `prisma:push` / etc. scripts that chain
+        // `prisma generate` so the client is never stale after a migration.
+        // (Prisma 7 removed the implicit generate-after-migrate behaviour.)
+        injectPrismaScripts(appDir);
 
         // Create PrismaService and PrismaModule
         const prismaDir = path.join(appDir, 'src/prisma');

--- a/packages/cli/src/commands/generate-service.ts
+++ b/packages/cli/src/commands/generate-service.ts
@@ -21,6 +21,7 @@ import { getPrismaDto } from '../templates/prisma-dto.template';
 import { getPrismaDtoClassValidator } from '../templates/prisma-dto-class-validator.template';
 import { getPrismaServiceFile, getPrismaModuleFile, getPrismaAdapterPackage } from '../templates/prisma-setup.template';
 import { configurePrismaGenerator, ignoreGeneratedPrismaClient } from '../lib/configure-prisma-generator';
+import { injectPrismaScripts } from '../lib/inject-prisma-scripts';
 import { getTypeOrmEntity } from '../templates/typeorm-entity.template';
 import { getTypeOrmService } from '../templates/typeorm-service.template';
 import { getTypeOrmModule } from '../templates/typeorm-module.template';
@@ -130,6 +131,10 @@ const ensurePrismaSetup = async (projectDir: string, dbType: string): Promise<vo
         // generated client out of version control.
         configurePrismaGenerator(projectDir);
         ignoreGeneratedPrismaClient(projectDir);
+
+        // Inject `prisma:migrate` / `prisma:push` / etc. scripts that chain
+        // `prisma generate` so the client is never stale after a migration.
+        injectPrismaScripts(projectDir);
     }
 
     // Create PrismaService and PrismaModule if they don't exist

--- a/packages/cli/src/lib/inject-prisma-scripts.ts
+++ b/packages/cli/src/lib/inject-prisma-scripts.ts
@@ -1,0 +1,55 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import * as chalk from 'chalk';
+
+/*
+ Prisma 7 removed the implicit `prisma generate` that used to run after
+ `prisma migrate dev`. To make sure the generated client never goes stale,
+ we inject a set of convenience scripts into the app's package.json so that
+ running `prisma:migrate` (or `prisma:push`) always regenerates the client
+ automatically.
+
+ Scripts added:
+   prisma:generate  – npx prisma generate
+   prisma:migrate   – npx prisma migrate dev  &&  npx prisma generate
+   prisma:push      – npx prisma db push       &&  npx prisma generate
+   prisma:studio    – npx prisma studio
+   prisma:reset     – npx prisma migrate reset  &&  npx prisma generate
+ */
+export const injectPrismaScripts = (projectDir: string): void => {
+    const pkgJsonPath = path.join(projectDir, 'package.json');
+
+    if (!fs.existsSync(pkgJsonPath)) {
+        console.warn(chalk.yellow('Warning: package.json not found. Skipping Prisma script injection.'));
+        return;
+    }
+
+    const appPkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    appPkg.scripts = appPkg.scripts || {};
+
+    const scripts: Record<string, string> = {
+        'prisma:generate': 'npx prisma generate',
+        // migrate dev + immediate generate so the client is never stale
+        'prisma:migrate':  'npx prisma migrate dev && npx prisma generate',
+        // db push is handy during prototyping
+        'prisma:push':     'npx prisma db push && npx prisma generate',
+        'prisma:studio':   'npx prisma studio',
+        // reset also re-seeds; regenerate client afterwards
+        'prisma:reset':    'npx prisma migrate reset && npx prisma generate',
+    };
+
+    let added = 0;
+    for (const [key, value] of Object.entries(scripts)) {
+        if (!appPkg.scripts[key]) {
+            appPkg.scripts[key] = value;
+            added++;
+        }
+    }
+
+    if (added > 0) {
+        fs.writeFileSync(pkgJsonPath, JSON.stringify(appPkg, null, 2) + '\n');
+        console.log(chalk.green(`Injected ${added} Prisma script(s) into package.json`));
+        console.log(chalk.gray('  Use `npm run prisma:migrate` instead of `npx prisma migrate dev`'));
+        console.log(chalk.gray('  This chains prisma generate automatically so the client stays fresh.'));
+    }
+};


### PR DESCRIPTION
prisma 7.0 removed the automatic prisma generate step that previously ran after prisma migrate dev and prisma db push. As a result, projects scaffolded with @nest-extended/cli using the new prisma-client generator end up with a stale Prisma Client after schema changes. Newly added models aren't available on PrismaClient until prisma generate is run manually.


Root Cause is : 

From [Prisma 7.0.0 release notes](https://github.com/prisma/prisma/releases/tag/7.0.0):
> In previous releases, `prisma migrate` would run `prisma generate` and `prisma seed

Because @nest-extended/cli relied on the previous behavior, the generated projects no longer regenerate the Prisma Client after schema changes. This causes TypeScript errors such as Property 'model-name' does not exist on type 'PrismaClient' until the client is regenerated manually.